### PR TITLE
Fix numbers always being added as a prefix

### DIFF
--- a/batch_export.py
+++ b/batch_export.py
@@ -33,7 +33,7 @@ class Options():
 
         # File naming page
         self.naming_scheme = batch_exporter.options.naming_scheme
-        self.use_number_prefix = batch_exporter.options.use_number_prefix
+        self.use_number_prefix = self._str_to_bool(batch_exporter.options.use_number_prefix)
         self.name_template = batch_exporter.options.name_template
 
         # Help page


### PR DESCRIPTION
Numbers were always being added as the prefix for filenames when using `simple naming scheme` due to the export option not being converted to a boolean.