### PR TITLE
Adding option to aggregate layers, bottom to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ After the extension is installed, it can be found in the **Extensions** menu, **
     * If you want to export the files in PDF format you can choose the PDF version to be used(1.4 or 1.5).
     * Choose a layer export mode (this feature is independent from the **Use background layers**):
         * Export each layer as a single layer - the export file will contain only the objects from this layer
-        * Use parent layers as background layers - the export file will contain the objects from the parent layers as well
+        * Aggregate lower layers as background layers - the export file will contain the objects from the lower layers as well
+        * Use parent layers as background layers - the export file will contain the objects from the parent layers as well (drag and drop a layer onto another layer in inkscape to create hierarchy)
 
 * Other options
     * Check the **Use background layers** options if you want to have one or more layers that will appear in all exports. You also need to name these layers with a fixed tag at the beginning.

--- a/batch_export.inx
+++ b/batch_export.inx
@@ -25,7 +25,8 @@
         <item value="1.5">1.5</item>
       </param>
       <param name="hierarchical-layers" type="enum" gui-text="Layer export mode:" indent="1">
-        <item value="solo">Export each layer as a single layer</item>
+        <item value="None">Export each layer as a single layer</item>
+        <item value="aggregated">Aggregate lower layers as background layers</item>
         <item value="hierarchical">Use parent layers as background layers</item>
       </param>
 


### PR DESCRIPTION
Love this extension, great work with it!
I was looking for a way to export the layers by aggregating them. So with three layers in an svg there are three exported images, 
- one with only the bottom layer, 
- one with bottom and middle layers,
- one with bottom middle and top layers.

I tried to make it work with the `Use parent layers as background layers` option but found no obvious option in inkscape to create the parent child connection. If there is one then I would appreciate some pointers on how and maybe a short guide can be added in the `README.md`. If there is not a straightforward solution for this, I did a solution by adding an option in the `Layer export mode` that makes aggregation possible without any parent layers. If you think it adds something to your repo I will gladly make adjustments to this commit so that it fits perfectly into your code.

Sincerely,
Adrian